### PR TITLE
Include Tornado 4.5 patch

### DIFF
--- a/recipe/PR_6155.diff
+++ b/recipe/PR_6155.diff
@@ -1,0 +1,38 @@
+diff --git bokeh/util/tornado.py bokeh/util/tornado.py
+index 45834a2..03398d3 100644
+--- bokeh/util/tornado.py
++++ bokeh/util/tornado.py
+@@ -16,6 +16,12 @@ def yield_for_all_futures(result):
+     the Future is another Future we yield until it's done as well, and so on.
+     """
+     while True:
++
++        # This is needed for Tornado >= 4.5 where convert_yielded will no
++        # longer raise BadYieldError on None
++        if result is None:
++            break
++
+         try:
+             future = gen.convert_yielded(result)
+         except gen.BadYieldError:
+@@ -23,6 +29,7 @@ def yield_for_all_futures(result):
+             break
+         else:
+             result = yield future
++
+     raise gen.Return(result)
+ 
+ class _AsyncPeriodic(object):
+@@ -56,6 +63,12 @@ def invoke():
+             # the period.
+             sleep_future = self.sleep()
+             result = self._func()
++
++            # This is needed for Tornado >= 4.5 where convert_yielded will no
++            # longer raise BadYieldError on None
++            if result is None:
++                return sleep_future
++
+             try:
+                 callback_future = gen.convert_yielded(result)
+             except gen.BadYieldError:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,8 +43,7 @@ requirements:
     - python-dateutil >=2.1
     - jinja2 >=2.7
     - numpy >=1.7.1
-    # review <4.5 when the next release is available.
-    - tornado >=4.3,<4.5
+    - tornado >=4.3
     - futures >=3.0.3         # [py2k]
     - pandas
     - matplotlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,12 @@ source:
     # ref: https://github.com/bokeh/bokeh/pull/6114  #
     ##################################################
     - PR_6114.diff
+    ##################################################
+    # Include a patch for newer tornado versions.    #
+    #                                                #
+    # ref: https://github.com/bokeh/bokeh/pull/6155  #
+    ##################################################
+    - PR_6155.diff
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
     - PR_6155.diff
 
 build:
-  number: 1
+  number: 2
   script: python setup.py install --single-version-externally-managed --record record.txt
   entry_points:
     - bokeh = bokeh.__main__:main


### PR DESCRIPTION
Fixes https://github.com/conda-forge/bokeh-feedstock/issues/8

Backports the patch from PR ( https://github.com/bokeh/bokeh/pull/6155 ) for Tornado 4.5+ support.