### PR TITLE
NO MRG: Test 0.12.13rc2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "bokeh" %}
-{% set version = "0.12.11" %}
-{% set checksum = "d29b544dd4576900774773a951bf61e2e0a0456d0b065baf48cbf30a8e0c0e95" %}
+{% set version = "0.12.13rc2" %}
+{% set checksum = "30fa2a7d27939e3814f0097e561877b70492962f0dd254a5594a86e3bc1d1ee1" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://anaconda.org/bokeh/bokeh/{{ version }}/download/bokeh-{{ version }}.tar.gz
   sha256: {{ checksum }}
 
 build:


### PR DESCRIPTION
Tries building the `0.12.13rc2` release of `bokeh` to see if it fixes issues experienced on Windows. ( https://github.com/conda-forge/bokeh-feedstock/pull/16 ) ( https://github.com/bokeh/bokeh/issues/7283 ) ( https://github.com/conda-forge/bokeh-feedstock/pull/17 )

cc @bryevdv