### PR TITLE
Release 0.12.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "bokeh" %}
-{% set version = "0.12.11" %}
-{% set checksum = "d29b544dd4576900774773a951bf61e2e0a0456d0b065baf48cbf30a8e0c0e95" %}
+{% set version = "0.12.13" %}
+{% set checksum = "6e28cbfd88de0c459435278b75f9982591ec0aaa3d37a195052645e1c62e89e3" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
```
2017-12-06  0.12.13:
--------------------
  * bugfixes:
    - #7283 [component: build] Windows install fails 0.12.12

2017-12-05  0.12.12:
--------------------
  * bugfixes:
    - #6588 [typescript] Model references are not resolved when trying to change ranges and attach js callback at the same time
    - #7268 [component: bokehjs] [notebook] Push_notebook regression in 0.12.11
    - #7282 [component: bokehjs] Add missing return statements to get_indices typescript version
  * tasks:
    - #7214 [component: bokehjs] [component: build] Allow es6 output from bokehjs' build
    - #7276 Unclear exception when bokeh_log_level env variable is set to a wrong value
    - #7279 [component: docs] Configuring plot tools documentation was unclear
```