### PR TITLE
Fix version constraint of packaging requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - python-dateutil >=2.1
     - jinja2 >=2.7
     - numpy >=1.7.1
-    - packaging
+    - packaging >=16.8
     - tornado >=4.3
     - futures >=3.0.3         # [py2k]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
   entry_points:
     - bokeh = bokeh.__main__:main


### PR DESCRIPTION
Adds the version constraint of the `packaging` requirement as 16.8+ and rebuilds.

ref: https://github.com/bokeh/bokeh/blob/0.12.14/setup.py#L95